### PR TITLE
homebrew with pulse audiochanges

### DIFF
--- a/quisk.c
+++ b/quisk.c
@@ -5716,7 +5716,6 @@ static PyMethodDef QuiskMethods[] = {
 	{"test_3", test_3, METH_VARARGS, "Test 3 function."},
 	{"tx_hold_state", tx_hold_state, METH_VARARGS, "Query or set the transmit hold state."},
 	{"set_fdx", set_fdx, METH_VARARGS, "Set full duplex mode; ignore the key status."},
-	{"sound_devices", quisk_sound_devices, METH_VARARGS, "Return a list of available sound device names."},
 #ifdef MS_WINDOWS
 	{"wasapi_sound_devices", quisk_wasapi_sound_devices, METH_VARARGS, "Return a list of available WASAPI sound device names."},
 #endif
@@ -5759,6 +5758,8 @@ static PyMethodDef QuiskMethods[] = {
 	{"watfall_GetPixels", watfall_GetPixels, METH_VARARGS, "Write the Waterfall image to be displayed."},
 #ifdef QUISK_HAVE_PULSEAUDIO
 	{"pa_sound_devices", quisk_pa_sound_devices, METH_VARARGS, "Return a list of available PulseAudio sound device names."},
+#else
+	{"sound_devices", quisk_sound_devices, METH_VARARGS, "Return a list of available sound device names."}
 #endif
 	{NULL, NULL, 0, NULL}		/* Sentinel */
 };

--- a/quisk.py
+++ b/quisk.py
@@ -4275,15 +4275,28 @@ class App(wx.App):
           self.sound_devices.append((1, 'wasapi:', description, device, '', ''))
     elif sys.platform == 'darwin':
       # start with portaudio: not alsa:
-      dev_capt, dev_play = QS.sound_devices()
-      for name in dev_capt:
+      try:
+        dev_capt, dev_play = QS.sound_devices()
+        for name in dev_capt:
           device = name
           description = name
           self.sound_devices.append((0, 'portaudio:', description, device, '', ''))
-      for name in dev_play:
-          device = name
-          description = name
-          self.sound_devices.append((1, 'portaudio:', description, device, '', ''))
+        for name in dev_play:
+            device = name
+            description = name
+            self.sound_devices.append((1, 'portaudio:', description, device, '', ''))
+      except:
+        self.sound_devices.append((0, 'pulse:', 'default', 'default', '', ''))
+        self.sound_devices.append((1, 'pulse:', 'default', 'default', '', ''))
+        dev_capt, dev_play = QS.pa_sound_devices()
+        for d in dev_capt:
+          print(d)
+        for d in dev_play:
+          print(d)
+        for device, description, alsa in dev_capt:
+            self.sound_devices.append((0, 'pulse:', description, device, '', ''))
+        for device, description, alsa in dev_play:
+            self.sound_devices.append((1, 'pulse:', description, device, '', ''))
     else:
       dev_capt, dev_play = QS.sound_devices()
       for name in dev_capt:

--- a/quisk.py
+++ b/quisk.py
@@ -4289,10 +4289,6 @@ class App(wx.App):
         self.sound_devices.append((0, 'pulse:', 'default', 'default', '', ''))
         self.sound_devices.append((1, 'pulse:', 'default', 'default', '', ''))
         dev_capt, dev_play = QS.pa_sound_devices()
-        for d in dev_capt:
-          print(d)
-        for d in dev_play:
-          print(d)
         for device, description, alsa in dev_capt:
             self.sound_devices.append((0, 'pulse:', description, device, '', ''))
         for device, description, alsa in dev_play:

--- a/sound_pulseaudio.c
+++ b/sound_pulseaudio.c
@@ -1009,3 +1009,16 @@ PyObject * quisk_pa_sound_devices(PyObject * self, PyObject * args)
     //printf("Finished with name loop\n");
 	return pylist;
 }
+
+#if !defined(QUISK_HAVE_ALSA) && !defined(QUISK_HAVE_WASAPI)
+//
+// quisk_control_midi and the CW-MIDI status variable are defined in these two
+// modules. If they are not present, we must provide a dummy here. On MacOS,
+// we can even provide a functional replacement (ToDO)
+
+PyObject * quisk_control_midi(PyObject * self, PyObject * args, PyObject * keywds)
+{
+return Py_None;
+}
+int quisk_midi_cwkey = 0;
+#endif


### PR DESCRIPTION
The only remaining problem I see, is having both pulseaudio and portaudio libraries disables the pulse code during the conditional compile. I don't know if this is also an issue on linux, but few people use portaudio on linux.

